### PR TITLE
Revert "#8: Try 180x110 image size"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta prefix="og: http://ogp.me/ns#" property="og:image" content="img/thumbnail.png" />
-  <meta prefix="og: http://ogp.me/ns#" property="og:image:height" content="110" />
-  <meta prefix="og: http://ogp.me/ns#" property="og:image:width" content="180" />
+  <meta prefix="og: http://ogp.me/ns#" property="og:image:height" content="400" />
+  <meta prefix="og: http://ogp.me/ns#" property="og:image:width" content="500" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Benjamin Johnson</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Sans+Pro:900" rel="stylesheet">


### PR DESCRIPTION
Reverts benjaminj6/portfolio#9

Turns out this wasn't as necessary as I thought...the LinkedIn UI when adding images doesn't show the full thumbnail. Now have checked it a bit more and the entire image is showing